### PR TITLE
Security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "^1.25"
       - name: "Checkup"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
         with:
           # Will fetch all history and tags required to generate version
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "^1.15.5"
       - name: "Checkup"
@@ -22,7 +22,7 @@ jobs:
         run: go build
       - name: "Git Version"
         id: generate-version
-        uses: codacy/git-version@2.4.0
+        uses: codacy/git-version@fa06788276d7492a2af01662649696d249ecf4cb # 2.4.0
       - name: "Tag version"
         run: |
           git tag ${{ steps.generate-version.outputs.version }}
@@ -34,7 +34,7 @@ jobs:
           docker tag "codacy/pulse-event-cli:${{ steps.generate-version.outputs.version }}" "codacy/pulse-event-cli:${{ steps.generate-version.outputs.version }}"
           docker tag "codacy/pulse-event-cli:${{ steps.generate-version.outputs.version }}" "codacy/pulse-event-cli:latest"
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7 # v1.12.0
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -43,14 +43,14 @@ jobs:
           docker push "codacy/pulse-event-cli:${{ steps.generate-version.outputs.version }}"
           docker push "codacy/pulse-event-cli:latest"
       - name: Push binaries to GitHub
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: latest
           args: release --clean
       - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-1
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -79,7 +79,7 @@ jobs:
             aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_ID} --paths "/${BINARY_PATH}/latest"
           fi
       - name: "Push data to pulse"
-        uses: codacy/pulse-action@0.0.3
+        uses: codacy/pulse-action@dd15d61f61272a7b4395e88de12d4f7d38b61686 # 0.0.3
         with:
           args: |
             push git deployment \


### PR DESCRIPTION
Pins all GitHub Actions from mutable tags/branches to immutable SHA hashes.

This prevents supply chain attacks like the TeamPCP/Trivy incident (March 2026), where attackers force-pushed tags to point at malicious commits.

Auto-generated by the Codacy security audit script.